### PR TITLE
feat: 응답을 위한 클래스 분리작업

### DIFF
--- a/src/main/java/com/yunboklog/api/Controller/PostController.java
+++ b/src/main/java/com/yunboklog/api/Controller/PostController.java
@@ -2,6 +2,7 @@ package com.yunboklog.api.Controller;
 
 import com.yunboklog.api.domain.Post;
 import com.yunboklog.api.request.PostCreate;
+import com.yunboklog.api.response.PostResponse;
 import com.yunboklog.api.service.PostService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,8 +28,8 @@ public class PostController {
     }
 
     @GetMapping("/posts/{postId}")
-    public Post get(@PathVariable(name = "postId") Long id) {
-        Post post = postService.get(id);
-        return post;
+    public PostResponse get(@PathVariable(name = "postId") Long id) {
+        PostResponse postResponse = postService.get(id);
+        return postResponse;
     }
 }

--- a/src/main/java/com/yunboklog/api/response/PostResponse.java
+++ b/src/main/java/com/yunboklog/api/response/PostResponse.java
@@ -1,0 +1,27 @@
+package com.yunboklog.api.response;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder
+public class PostResponse {
+
+    private Long id;
+    private String title;
+    private String content;
+
+    public PostResponse(Long id, String title, String content) {
+        this.id = id;
+        this.title = title.substring(0, 10);
+        this.content = content;
+    }
+
+
+
+
+
+
+}

--- a/src/main/java/com/yunboklog/api/service/PostService.java
+++ b/src/main/java/com/yunboklog/api/service/PostService.java
@@ -4,6 +4,7 @@ package com.yunboklog.api.service;
 import com.yunboklog.api.domain.Post;
 import com.yunboklog.api.repository.PostRepository;
 import com.yunboklog.api.request.PostCreate;
+import com.yunboklog.api.response.PostResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,11 +28,17 @@ public class PostService {
         postRepository.save(post);
     }
 
-    public Post get(Long id) {
+    public PostResponse get(Long id) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 글 입니다."));
 
-        return post;
+        PostResponse postResponse = PostResponse.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .build();
+
+        return postResponse;
     }
 
 

--- a/src/test/java/com/yunboklog/api/Controller/PostControllerTest.java
+++ b/src/test/java/com/yunboklog/api/Controller/PostControllerTest.java
@@ -98,4 +98,27 @@ class PostControllerTest {
         assertEquals("제목입니다.", post.getTitle());
         assertEquals("내용입니다.", post.getContent());
     }
+
+    @Test
+    @DisplayName("글 한개 조회 ")
+    void test4() throws Exception {
+        //given
+        Post post = Post.builder()
+                .title("123456789123456")
+                .content("bar")
+                .build();
+
+        postRepository.save(post);
+
+        // EXPECTED
+        mockMvc.perform(MockMvcRequestBuilders.get("/posts/{postId}", post.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(post.getId()))
+                .andExpect(jsonPath("$.title").value("1234567891"))
+                .andExpect(jsonPath("$.content").value("bar"))
+                .andDo(MockMvcResultHandlers.print());
+
+        //then
+    }
 }

--- a/src/test/java/com/yunboklog/api/service/PostServiceTest.java
+++ b/src/test/java/com/yunboklog/api/service/PostServiceTest.java
@@ -3,6 +3,7 @@ package com.yunboklog.api.service;
 import com.yunboklog.api.domain.Post;
 import com.yunboklog.api.repository.PostRepository;
 import com.yunboklog.api.request.PostCreate;
+import com.yunboklog.api.response.PostResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -59,7 +60,7 @@ class PostServiceTest {
         Long postId = 1L;
 
         // when
-        Post post = postService.get(requestPost.getId());
+        PostResponse post = postService.get(requestPost.getId());
 
         // then
         assertNotNull(post);


### PR DESCRIPTION
- Post 엔티티 객체를 직접 수정 할 경우 서비스 로직이 엔티티에  들어가게 되어 문제가 생길 가능성이 있음
- PostResponse 객체를 생성해서 분리한다.